### PR TITLE
Fix error checking that freezes the plugin

### DIFF
--- a/addons/godot-camera-plugin.funabab/camera_view.gd
+++ b/addons/godot-camera-plugin.funabab/camera_view.gd
@@ -3,7 +3,7 @@ extends Control
 
 const CameraViewNativeBridge = preload("camera_view_native_bridge.gd").CameraViewNativeBridge;
 const ERROR_FATAL = 1;
-const ICON_CAMERA = preload("icon_camera.png");
+var ICON_CAMERA = load("res://addons/godot-camera-plugin.funabab/icon_camera.png");
 const COLOR_BG = Color.black;
 
 enum ERROR {

--- a/addons/godot-camera-plugin.funabab/camera_view_native_bridge.gd
+++ b/addons/godot-camera-plugin.funabab/camera_view_native_bridge.gd
@@ -44,7 +44,7 @@ class CameraViewNativeBridge extends Reference:
 	func _on_picture_taken_(camera_error_code, data, detectedFacesExtra):
 		var _detectedFacesExtra = ParameterSerializer.unserialize(detectedFacesExtra);
 
-		if camera_error_code != __node__.OK:
+		if camera_error_code != OK:
 			__node__.emit_signal("picture_taken", camera_error_code, null, null);
 		else:
 			var image : Image = Image.new();

--- a/addons/godot-camera-plugin.funabab/plugin.gd
+++ b/addons/godot-camera-plugin.funabab/plugin.gd
@@ -5,7 +5,13 @@ const ANDROID_MODULE = "org/godotengine/godot/funabab/camera/FunababCameraPlugin
 const CUSTOM_NODE_NAME = "CameraView";
 
 func _enter_tree():
-	add_custom_type(CUSTOM_NODE_NAME, "Control", preload("camera_view.gd"), preload("icon_node.png"));
+	var custom_icon: Image = Image.new()
+	custom_icon.load("res://addons/godot-camera-plugin.funabab/icon_node.png")
+
+	var custom_icon_texture: ImageTexture = ImageTexture.new()
+	custom_icon_texture.create_from_image(custom_icon)
+
+	add_custom_type(CUSTOM_NODE_NAME, "Control", preload("camera_view.gd"), custom_icon_texture);
 	pass
 
 func _exit_tree():

--- a/addons/godot-camera-plugin.funabab/plugin.gd
+++ b/addons/godot-camera-plugin.funabab/plugin.gd
@@ -5,14 +5,7 @@ const ANDROID_MODULE = "org/godotengine/godot/funabab/camera/FunababCameraPlugin
 const CUSTOM_NODE_NAME = "CameraView";
 
 func _enter_tree():
-	var custom_icon: Image = Image.new()
-	custom_icon.load("res://addons/godot-camera-plugin.funabab/icon_node.png")
-
-	var custom_icon_texture: ImageTexture = ImageTexture.new()
-	custom_icon_texture.create_from_image(custom_icon)
-
-	add_custom_type(CUSTOM_NODE_NAME, "Control", preload("camera_view.gd"), custom_icon_texture);
-	pass
+	add_custom_type(CUSTOM_NODE_NAME, "Control", preload("camera_view.gd"), ResourceLoader.load("res://addons/godot-camera-plugin.funabab/icon_node.png"))
 
 func _exit_tree():
 	remove_custom_type(CUSTOM_NODE_NAME);

--- a/android/godot-camera-plugin.funabab/src/org/godotengine/godot/funabab/camera/FunababCameraPlugin.java
+++ b/android/godot-camera-plugin.funabab/src/org/godotengine/godot/funabab/camera/FunababCameraPlugin.java
@@ -12,6 +12,7 @@ import android.hardware.Camera;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ public class FunababCameraPlugin extends Godot.SingletonBase {
     private Context mContext;
     private Integer mInstanceId = null;
     private ViewGroup mRoot;
+    private FrameLayout layout = null;
 
     public static final String TAG = FunababCameraPlugin.class.getSimpleName();
     private static final int ERROR_CAMERA_NONE = 0;
@@ -54,8 +56,7 @@ public class FunababCameraPlugin extends Godot.SingletonBase {
                 }
 
                 mGodotCameraView = godotCameraView;
-                mRoot = (ViewGroup) mActivity.layout.getParent();
-                mRoot.addView(mGodotCameraView);
+                layout.addView(mGodotCameraView);
 
                 GodotLib.calldeferred(instanceId, "_set_camera_features_", new Object[]{
                         ParameterSerializer.serialize(mGodotCameraView.getCameraFeatures())
@@ -63,6 +64,12 @@ public class FunababCameraPlugin extends Godot.SingletonBase {
             }
         });
 	    return true;
+    }
+
+    @Override
+    public View onMainCreateView(Activity activity) {
+	    layout = new FrameLayout(activity);
+	    return layout;
     }
 
     public void resizeView(int instanceId, final int x, final int y, final int w, final int h) {

--- a/android/godot-camera-plugin.funabab/src/org/godotengine/godot/funabab/camera/FunababCameraPlugin.java
+++ b/android/godot-camera-plugin.funabab/src/org/godotengine/godot/funabab/camera/FunababCameraPlugin.java
@@ -23,7 +23,6 @@ public class FunababCameraPlugin extends Godot.SingletonBase {
     private Godot mActivity;
     private Context mContext;
     private Integer mInstanceId = null;
-    private ViewGroup mRoot;
     private FrameLayout layout = null;
 
     public static final String TAG = FunababCameraPlugin.class.getSimpleName();
@@ -111,7 +110,7 @@ public class FunababCameraPlugin extends Godot.SingletonBase {
 
     private void _destroyView() {
 	    if (mGodotCameraView != null) {
-	        mRoot.removeView(mGodotCameraView);
+	        layout.removeView(mGodotCameraView);
 	        mInstanceId = null;
         }
     }

--- a/demo.tscn
+++ b/demo.tscn
@@ -48,6 +48,7 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+face_recognition = false
 
 [node name="BtnTakePicture" type="Button" parent="VBoxContainer"]
 margin_top = 904.0


### PR DESCRIPTION
The plugin freeze when attempting to take picture due to broken error checking. Simple fix.